### PR TITLE
Fixed UnsupportedOperationException in LocalSocket

### DIFF
--- a/reon-api-android/src/main/java/io/reon/LocalSocketConnection.java
+++ b/reon-api-android/src/main/java/io/reon/LocalSocketConnection.java
@@ -13,6 +13,8 @@ public class LocalSocketConnection implements Connection {
 	private final LocalSocket localSocket;
 	private InputStream is;
 
+	private volatile boolean closed;
+
 	public LocalSocketConnection(LocalSocket localSocket) {
 		this.localSocket = localSocket;
 	}
@@ -30,11 +32,12 @@ public class LocalSocketConnection implements Connection {
 
 	@Override
 	public boolean isClosed() {
-		return localSocket.isClosed();
+		return closed;
 	}
 
 	@Override
 	public void close() throws IOException {
+		closed = true;
 		localSocket.close();
 	}
 }

--- a/reon-api-android/src/main/java/io/reon/WebService.java
+++ b/reon-api-android/src/main/java/io/reon/WebService.java
@@ -2,10 +2,14 @@ package io.reon;
 
 import android.content.Intent;
 import android.os.IBinder;
+import android.util.Log;
 
 import java.io.IOException;
 
 public abstract class WebService extends android.app.Service {
+
+	private static final String LOG_TAG = WebService.class.getSimpleName();
+
 	public final static String EXTRA_TARGET = "uri";
 
 	@Override
@@ -14,7 +18,7 @@ public abstract class WebService extends android.app.Service {
 			try {
 				return new WebBinder(getBinder(), intent.getStringExtra(EXTRA_TARGET));
 			} catch (IOException e) {
-				e.printStackTrace();
+				Log.e(LOG_TAG, "Error obtaining web binder", e);
 				return null;
 			}
 		}


### PR DESCRIPTION
Problem:
`LocalSocketConnection.isClosed()` calls `android.net.LocalSocket.isClosed()` which always throws `UnsupportedOperationException`.

Solution:
Using flag in `LocalSocketConnection` instead of calling `android.net.LocalSocket.isClosed()`.
