### PR TITLE
Connection can be closed by response

### DIFF
--- a/reon-api-java/src/main/java/io/reon/http/AbstractServerTask.java
+++ b/reon-api-java/src/main/java/io/reon/http/AbstractServerTask.java
@@ -50,7 +50,7 @@ public abstract class AbstractServerTask implements Runnable {
 						}
 						response.setId(requestId);
 						writer.write(response);
-						keepAlive = !request.shouldClose();
+						keepAlive = !request.shouldClose() && !response.shouldClose();
 						// make sure request body has been read
 						if (keepAlive) request.readBody();
 					} else keepAlive = false;


### PR DESCRIPTION
Connection should not be kept alive, when either request or response has header `Connection: close`.
