### PR TITLE
Unauthorized response should not close connection

### DIFF
--- a/reon-api-java/src/main/java/io/reon/RequestTask.java
+++ b/reon-api-java/src/main/java/io/reon/RequestTask.java
@@ -26,7 +26,7 @@ public class RequestTask extends AbstractServerTask {
 						.build();
 		} else {
 			if(!context.getClientTokenAuth().verify(authToken))
-				return ResponseBuilder.forbidden().withClose().build();
+				return ResponseBuilder.forbidden().build();
 		}
 		return null;
 	}

--- a/reon-api-java/src/main/java/io/reon/http/ResponseBuilder.java
+++ b/reon-api-java/src/main/java/io/reon/http/ResponseBuilder.java
@@ -28,7 +28,7 @@ public class ResponseBuilder extends MessageBuilder<Response> {
 	}
 
 	public static ResponseBuilder notFound() {
-		return startWith(StatusCode.NOT_FOUND).withClose();
+		return startWith(StatusCode.NOT_FOUND);
 	}
 
 	public static ResponseBuilder error(HttpException ex) {

--- a/reon-api-java/src/main/java/io/reon/http/ResponseBuilder.java
+++ b/reon-api-java/src/main/java/io/reon/http/ResponseBuilder.java
@@ -40,7 +40,7 @@ public class ResponseBuilder extends MessageBuilder<Response> {
 	}
 
 	public static ResponseBuilder unauthorized() {
-		return startWith(StatusCode.UNAUTHORIZED).withClose();
+		return startWith(StatusCode.UNAUTHORIZED);
 	}
 
 	public static ResponseBuilder serviceUnavailable() {


### PR DESCRIPTION
After response "401 Unauthorized", connection should be kept alive, waiting for authorization token.
